### PR TITLE
refactor(session): add pause/resume logic and restructure session han…

### DIFF
--- a/background.js
+++ b/background.js
@@ -20,10 +20,11 @@ async function checkTab(tabId, changeInfo, tab) {
   const data = await chrome.storage.local.get("focusSession");
   const session = data.focusSession;
 
-  if (!session || !session.active) return;
+  if (!session || (session.status !== "running" && session.status !== "paused")) {
+    return;
+  }
 
   const blockedPageUrl = chrome.runtime.getURL("blocked.html");
-
   if (tab.url.startsWith(blockedPageUrl)) return; // Prevent loop
 
   if (!isUrlWhitelisted(tab.url, session.whitelist)) {
@@ -35,7 +36,9 @@ chrome.tabs.onCreated.addListener(async (tab) => {
   const data = await chrome.storage.local.get("focusSession");
   const session = data.focusSession;
 
-  if (!session || !session.active) return;
+  if (!session || (session.status !== "running" && session.status !== "paused")) {
+    return;
+  }
 
   const blockedPageUrl = chrome.runtime.getURL("blocked.html");
   const url = tab.pendingUrl || tab.url || "";

--- a/style.css
+++ b/style.css
@@ -174,7 +174,7 @@ body {
 }
 
 .btn {
-  width: 100%;
+  width: 100px;
   font-weight: bold;
   font-size: 0.75rem;
   padding: 0.5rem;


### PR DESCRIPTION
Implemented pause and resume functionality for focus sessions. 
Refactored session logic to clearly separate UI state ("idle", "running", "paused") 
from stored session state in chrome.storage. Introduced centralized functions like 
updateUIState() and saveSession() to improve maintainability.

Changes:
- Added "paused" state tracking to session object.
- UI updates cleanly based on session status.
- Session blocking still enforced while paused.
- Countdown resumes correctly after pause.
- Session state now survives popup reloads.

This lays groundwork for future enhancements like session history or lock-in modes.

Closes #17 