### PR TITLE
fix(ui): prevent long tab titles from shrinking toggle button

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -216,38 +216,27 @@ document.addEventListener("DOMContentLoaded", () => {
       checkbox.type = "checkbox";
       checkbox.value = domain;
 
-      const favicon = document.createElement("img");
-      favicon.src = tab.favIconUrl || "";
-      favicon.style.width = "16px";
-      favicon.style.height = "16px";
-      favicon.style.verticalAlign = "middle";
-      favicon.style.marginRight = "5px";
+      const labelContainer = document.createElement("div");
+      labelContainer.className = "label-container";
 
+      const favicon = document.createElement("img");
+      favicon.className = "favicon";
+      favicon.src = tab.favIconUrl || "";
       favicon.onerror = () => {
         favicon.onerror = null;
         favicon.src = `https://www.google.com/s2/favicons?sz=64&domain=${domain}`;
       };
 
-      const label = document.createElement("label");
-      label.style.whiteSpace = "nowrap";
-      label.style.overflow = "hidden";
-      label.style.textOverflow = "ellipsis";
-      label.style.display = "inline-block";
-      label.style.maxWidth = "250px";
-      label.style.marginLeft = "5px";
-
-      const maxLen = 28;
+      const titleSpan = document.createElement("span");
+      titleSpan.className = "title";
       const fullTitle = tab.title || tab.url;
-      const shortTitle = fullTitle.length > maxLen ? fullTitle.slice(0, maxLen - 1) + "…" : fullTitle;
-      label.textContent = shortTitle;
-      label.title = fullTitle;
+      titleSpan.textContent = fullTitle;
+      titleSpan.title = fullTitle;
 
-      const innerLabel = document.createElement("label");
-      innerLabel.className = "label";
-      innerLabel.appendChild(favicon);
-      innerLabel.appendChild(label);
+      labelContainer.appendChild(favicon);
+      labelContainer.appendChild(titleSpan);
 
-      div.appendChild(innerLabel);
+      div.appendChild(labelContainer);
       div.appendChild(checkbox);
 
       container.appendChild(div);

--- a/style.css
+++ b/style.css
@@ -132,14 +132,19 @@ body {
   justify-content: space-between;
   padding: 0.4rem 0.6rem;
   border-radius: 0.5rem;
+  position: relative; /* for blur overlay */
 }
 
 .item label {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
   font-size: 0.95rem;
   font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  margin-right: 0.75rem;
 }
 
 .item input[type="checkbox"] {
@@ -151,6 +156,7 @@ body {
   position: relative;
   cursor: pointer;
   transition: background 0.3s ease;
+  z-index: 1; /* keeps it on top of blur */
 }
 
 .item input[type="checkbox"]:checked {
@@ -171,6 +177,38 @@ body {
 
 .item input[type="checkbox"]:checked::before {
   transform: translateX(16px);
+}
+
+.item::after {
+  content: "";
+  position: absolute;
+  right: 42px; /* slightly more than toggle width */
+  top: 0;
+  height: 100%;
+  width: 30px;
+  background: linear-gradient(to left, #1f2937, transparent);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.label-container {
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  flex: 1;
+  margin-right: 0.5rem;
+}
+
+.favicon {
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+.title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .btn {


### PR DESCRIPTION
Previously, long tab titles in the tab list would stretch the container and shrink the toggle switch, breaking visual consistency. 

This commit restructures the DOM by separating the label container from the checkbox and applies flex behavior to ensure that long titles are truncated or masked, while the toggle remains fixed in size and position. 

CSS was adjusted to:
- Add `.label-container` with proper flex and overflow rules
- Apply consistent styling to `.favicon` and `.title`
- Prevent title overflow from affecting the toggle area

This fixes the visual layout and keeps the toggle button's interaction and appearance stable regardless of title length.


Closes #20 