### PR TITLE
Add unit tests for getTimeLeft and createNewSession

### DIFF
--- a/test/session.test.js
+++ b/test/session.test.js
@@ -1,4 +1,5 @@
-import { getTimeLeft } from "../src/popup/session.js";
+import { jest } from '@jest/globals';
+import { getTimeLeft, createNewSession } from "../src/popup/session.js";
 
 describe("getTimeLeft", () => {
   test("returns correct time difference in seconds", () => {
@@ -16,5 +17,49 @@ describe("getTimeLeft", () => {
 
     // Clean up
     Date.now = originalNow;
+  });
+});
+
+describe("createNewSession", () => {
+  it("should return a valid session object", () => {
+    // Arrange
+    const totalSeconds = 120;
+    const whitelist = ["https://example.com", "https://another.com"];
+    const before = Date.now();
+
+    // Act
+    const session = createNewSession(totalSeconds, whitelist);
+    const after = Date.now();
+
+    // Assert
+    expect(session.status).toBe("running");
+    expect(session.originalTime).toBe(totalSeconds);
+    expect(session.whitelist).toEqual(whitelist);
+
+    // Check that endTime is within a reasonable window (±50ms)
+    const expectedEndTimeMin = before + totalSeconds * 1000;
+    const expectedEndTimeMax = after + totalSeconds * 1000;
+    expect(session.endTime).toBeGreaterThanOrEqual(expectedEndTimeMin);
+    expect(session.endTime).toBeLessThanOrEqual(expectedEndTimeMax);
+  });
+});
+
+import { saveSession } from '../src/popup/session.js';
+
+describe('saveSession', () => {
+  beforeEach(() => {
+    global.chrome = {storage: { local: { set: jest.fn() }}};});
+
+  it('calls chrome.storage.local.set with correct session object', () => {
+    const session = {
+      status: "running",
+      endTime: 1234567890,
+      originalTime: 300,
+      whitelist: ["https://example.com"]
+    };
+
+    saveSession(session);
+
+    expect(chrome.storage.local.set).toHaveBeenCalledWith({ focusSession: session });
   });
 });


### PR DESCRIPTION
This commit introduces unit tests for two core session-related functions:
* getTimeLeft(session): Ensures accurate calculation of remaining session time in seconds.
* createNewSession(totalSeconds, whitelist): Validates the structure of the session object, including correct initialization of endTime, status, and whitelist.

These tests help verify session initialization and time tracking logic.