### PR TITLE
Fix: Timer now correctly counts down to 00:00:00 before ending

### DIFF
--- a/src/popup/session.js
+++ b/src/popup/session.js
@@ -42,7 +42,7 @@ function startCountdown(
   let remaining = totalSeconds;
 
   interval = setInterval(() => {
-    remaining--;
+    updateInputsFromSeconds(remaining, timer.hrInput, timer.minInput, timer.secInput);
 
     if (remaining <= 0) {
       clearInterval(interval);
@@ -51,7 +51,7 @@ function startCountdown(
       return;
     }
 
-    updateInputsFromSeconds(remaining, timer.hrInput, timer.minInput, timer.secInput); // Handle UI updates every second
+    remaining--;
   }, 1000);
 }
 

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -109,7 +109,8 @@ describe('startCountdown', () => {
     expect(updateMock).toHaveBeenCalledTimes(1);
 
     jest.advanceTimersByTime(2000); // Total 3 seconds
-    expect(updateMock).toHaveBeenCalledTimes(2);
+    jest.runOnlyPendingTimers();
+    expect(updateMock).toHaveBeenCalledTimes(4);
     expect(onEndMock).toHaveBeenCalledWith(controllerMock, timerMock);
     expect(chrome.storage.local.clear).toHaveBeenCalled();
   });


### PR DESCRIPTION
- Reordered countdown logic to ensure updateInputsFromSeconds(...) is called before checking if the timer has hit zero.
- This prevents the timer from stopping early at 1 second and ensures the UI displays 00:00 before the session ends.
- Also ensured the session end logic still clears storage and triggers the onEnd callback.
- Updated unit test to reflect the corrected countdown behavior by expecting 4 UI updates (3 → 2 → 1 → 0) instead of 2.
- Added jest.runOnlyPendingTimers() to simulate the final timer tick and confirm that onEnd is called after 0 is shown.

Closes #41 