### PR TITLE
fix: properly end session and display completion badge

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,8 @@
     "tabs",
     "storage",
     "scripting",
-    "activeTab"
+    "activeTab",
+    "alarms"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/src/background.js
+++ b/src/background.js
@@ -1,11 +1,3 @@
-chrome.runtime.onStartup.addListener(() => {
-  chrome.storage.local.remove(["focusSession", "sessionStatus", "sessionStartTime"]);
-});
-
-chrome.runtime.onInstalled.addListener(() => {
-  chrome.storage.local.remove(["focusSession", "sessionStatus", "sessionStartTime"]);
-});
-
 function isUrlWhitelisted(url, whitelist) {
   try {
     const parsedUrl = new URL(url);
@@ -49,6 +41,14 @@ async function checkTab(tabId, changeInfo, tab) {
   }
 }
 
+chrome.runtime.onStartup.addListener(() => {
+  chrome.storage.local.remove(["focusSession", "sessionStatus", "sessionStartTime"]);
+});
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.storage.local.remove(["focusSession", "sessionStatus", "sessionStartTime"]);
+});
+
 chrome.tabs.onCreated.addListener(async (tab) => {
   const data = await chrome.storage.local.get("focusSession");
   const session = data.focusSession;
@@ -83,6 +83,7 @@ chrome.tabs.onCreated.addListener(async (tab) => {
 });
 
 chrome.tabs.onUpdated.addListener(checkTab);
+
 chrome.tabs.onActivated.addListener(async (activeInfo) => {
   const tab = await chrome.tabs.get(activeInfo.tabId);
   checkTab(tab.id, null, tab);
@@ -91,5 +92,14 @@ chrome.tabs.onActivated.addListener(async (activeInfo) => {
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === "open-extension-settings") {
     chrome.tabs.create({ url: `chrome://extensions/?id=${chrome.runtime.id}` });
+  }
+});
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === "focusSessionEnd") {
+    chrome.storage.local.clear(() => {
+      chrome.action.setBadgeText({ text: "Done" });
+      chrome.action.setBadgeBackgroundColor({ color: "#10b981" }); // green
+    });
   }
 });

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -17,7 +17,9 @@ import {
   setupInputValidation,
   updateInputsFromSeconds,
   updateResumeButtonToPause,
-  updatePauseButtonToResume, 
+  updatePauseButtonToResume,
+  scheduleFocusSessionAlarm,
+  clearFocusSessionAlarmAndBadge
 } from './ui.js';
 
 function onEnd(controller, timer) {
@@ -44,7 +46,7 @@ document.addEventListener("DOMContentLoaded", () => {
     renderTabList(tabs);
   });
 
-  checkSession(onEnd, getTimeLeft, updateUIState, startCountdown, updateInputsFromSeconds, updatePauseButtonToResume, controller, timer);
+  checkSession(onEnd, getTimeLeft, updateUIState, startCountdown, updateInputsFromSeconds, updatePauseButtonToResume, clearFocusSessionAlarmAndBadge, controller, timer);
 
   startBtn.addEventListener("click", () => {
     const totalSeconds = getTotalSeconds(hrInput, minInput, secInput);
@@ -60,6 +62,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const session = createNewSession(totalSeconds, whitelist);
 
     saveSession(session);
+    scheduleFocusSessionAlarm(totalSeconds);
+
     startCountdown(totalSeconds, onEnd, updateInputsFromSeconds, controller, timer);
     updateUIState("running",controller, timer);
   });
@@ -67,7 +71,21 @@ document.addEventListener("DOMContentLoaded", () => {
   pauseBtn.addEventListener("click", () => {
     
     const totalSeconds = getTotalSeconds(hrInput,minInput,secInput);
-    togglePauseResume(totalSeconds, onEnd, saveSession, pauseSession, updateUIState, startCountdown, updateInputsFromSeconds, updatePauseButtonToResume, updateResumeButtonToPause, controller, timer);
+    togglePauseResume(
+      totalSeconds, 
+      onEnd, 
+      saveSession, 
+      pauseSession, 
+      updateUIState, 
+      startCountdown, 
+      updateInputsFromSeconds, 
+      updatePauseButtonToResume, 
+      updateResumeButtonToPause, 
+      scheduleFocusSessionAlarm,
+      clearFocusSessionAlarmAndBadge, 
+      controller, 
+      timer
+    );
 
   });
 
@@ -76,7 +94,17 @@ document.addEventListener("DOMContentLoaded", () => {
       
       const session = data.focusSession || {};
       const totalSeconds = getTotalSeconds(hrInput,minInput,secInput);
-      handleStop(session, totalSeconds, saveSession,  pauseSession, updateUIState, updatePauseButtonToResume, controller, timer);
+      handleStop(
+        session, 
+        totalSeconds, 
+        saveSession,  
+        pauseSession, 
+        updateUIState, 
+        updatePauseButtonToResume, 
+        clearFocusSessionAlarmAndBadge, 
+        controller, 
+        timer
+      );
 
     });
   });

--- a/src/popup/ui.js
+++ b/src/popup/ui.js
@@ -63,6 +63,19 @@ function showFloatingWarning(message = "Please select at least one tab before st
   document.addEventListener("keydown", removeWarning, true);
 }
 
+function scheduleFocusSessionAlarm(totalSeconds) {
+  chrome.alarms.clear("focusSessionEnd", () => {
+    chrome.alarms.create("focusSessionEnd", {
+      when: Date.now() + totalSeconds * 1000,
+    });
+  });
+}
+
+function clearFocusSessionAlarmAndBadge() {
+  chrome.alarms.clear("focusSessionEnd");
+  chrome.action.setBadgeText({ text: "" });
+}
+
 function setupInputValidation(hrInput, minInput, secInput) {
   if (!hrInput || !minInput || !secInput) return;
 
@@ -162,4 +175,6 @@ export {
   updateInputsFromSeconds,
   updatePauseButtonToResume,
   updateResumeButtonToPause,
+  scheduleFocusSessionAlarm,
+  clearFocusSessionAlarmAndBadge,
 };


### PR DESCRIPTION
This update resolves an issue where tabs remained blocked even after the session timer had completed. The following changes were made to ensure proper session cleanup and user feedback:

- Introduced `scheduleFocusSessionAlarm` and `clearFocusSessionAlarmAndBadge` in `ui.js` to manage Chrome alarms and badges.
- Hooked these functions into `pauseSession`, `togglePauseResume`, and `checkSession` for lifecycle correctness.
- Updated `background.js` to handle the `focusSessionEnd` alarm by clearing session state and showing a green "Done" badge.
- Adjusted `session.test.js` to reflect injected dependencies and test alarm/badge logic.
- Added `"alarms"` permission in `manifest.json`.

This ensures that the session ends gracefully, tabs are no longer blocked, and the user is notified that focus time has concluded.

Closes #45 and #46 