### PR TITLE
Fix stop session handler to only remove session-related storage keys

### DIFF
--- a/src/visionboard/visionboard.js
+++ b/src/visionboard/visionboard.js
@@ -32,9 +32,12 @@ if (source === "settings") {
       const session = data.focusSession;
       if (!session || !session.originalTime) return;
 
-      chrome.storage.local.clear(() => {
-        window.close();
-      });
+      chrome.storage.local.remove(
+        ["focusSession", "sessionStatus", "sessionStartTime"],
+        () => {
+          window.close();
+        }
+      );
     });
   });
 }


### PR DESCRIPTION
Replaced chrome.storage.local.clear() with targeted remove() call to avoid deleting non-session data like uploaded vision board.

Closes #62 