### PR TITLE
chore: remove unused scripting permission from manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,6 @@
   "permissions": [
     "tabs",
     "storage",
-    "scripting",
     "activeTab",
     "alarms"
   ],


### PR DESCRIPTION
Removed the unused scripting permission from the manifest to reduce unnecessary permission scope and align with Chrome Web Store policy.

Closes #66 