### PR TITLE
Remove host_permissions and shift to activeTab

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,16 +2,13 @@
   "manifest_version": 3,
   "name": "ImpulseGuard",
   "version": "1.0",
-  "description": "Restrict distracting tabs and enforce focus sessions.",
+  "description": "Stops you from opening random sites while working.",
   "options_page": "src/settings/settings.html",
   "permissions": [
     "tabs",
     "storage",
     "activeTab",
     "alarms"
-  ],
-  "host_permissions": [
-    "<all_urls>"
   ],
   "background": {
     "service_worker": "src/background.js"

--- a/src/popup/ui.js
+++ b/src/popup/ui.js
@@ -64,16 +64,16 @@ function showFloatingWarning(message = "Please select at least one tab before st
 }
 
 function scheduleFocusSessionAlarm(totalSeconds) {
-  chrome.alarms.clear("focusSessionEnd", () => {
-    chrome.alarms.create("focusSessionEnd", {
-      when: Date.now() + totalSeconds * 1000,
-    });
+  chrome.runtime.sendMessage({
+    type: "scheduleFocusSessionAlarm",
+    totalSeconds: totalSeconds,
   });
 }
 
 function clearFocusSessionAlarmAndBadge() {
-  chrome.alarms.clear("focusSessionEnd");
-  chrome.action.setBadgeText({ text: "" });
+  chrome.runtime.sendMessage({
+    type: "clearFocusSessionAlarmAndBadge",
+  });
 }
 
 function setupInputValidation(hrInput, minInput, secInput) {


### PR DESCRIPTION
- Removed host_permissions from manifest.json to meet Chrome Store policies.
- Use activeTab to collect user-visible tabs on popup open.
- Moved alarm creation/clearing from ui.js to background.js using message passing.
- Unified background listeners under one onMessage handler.
- Ensured alarm reliability across popup closure and re-open cycles.

Closes #68 